### PR TITLE
Develop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main  # Ensures tag must be on the main branch
+
+jobs:
+  build-and-publish:
+    name: Build and Publish to PyPI
+    runs-on: ubuntu-latest
+
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') && github.ref_name != '' && github.ref_protected == true && github.repository == 'Jordonh18/sanitizr' && github.event.base_ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build the package
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Python Tests](https://github.com/Jordonh18/sanitizr/actions/workflows/python-tests.yml/badge.svg)](https://github.com/Jordonh18/sanitizr/actions/workflows/python-tests.yml)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://opensource.org/licenses/GPL-3.0)
 
-A powerful and modular URL cleaning library and CLI tool that removes tracking parameters and decodes redirects. **Currently in early development.**
+A powerful and modular URL cleaning library and CLI tool that removes tracking parameters and decodes redirects.
 
 ## Features
 
@@ -16,12 +16,10 @@ A powerful and modular URL cleaning library and CLI tool that removes tracking p
 
 ## Installation
 
-**Note:** Sanitizr is currently in early development and not yet available via pip. You can install it directly from the repository:
+You can install Sanitizr from PyPI:
 
 ```bash
-git clone https://github.com/Jordonh18/sanitizr.git
-cd sanitizr
-pip install -e .
+pip install sanitizr
 ```
 
 For development setup:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sanitizr"
-version = "0.1.0"
+version = "1.0.0"
 description = "Clean URLs by removing tracking parameters and decoding redirects"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -14,7 +14,7 @@ authors = [
     {name = "Sanitizr Contributors"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ black>=23.0
 isort>=5.12
 flake8>=6.0
 mypy>=1.0
+twine>=4.0.0,<5.0.0
+
 
 # Documentation dependencies
 mkdocs>=1.4

--- a/sanitizr/__init__.py
+++ b/sanitizr/__init__.py
@@ -9,7 +9,7 @@ import importlib.metadata
 try:
     __version__ = importlib.metadata.version("sanitizr")
 except importlib.metadata.PackageNotFoundError:
-    __version__ = "0.1.0.dev"
+    __version__ = "1.0.0"
 
 # Import from subpackage for easier access
 from sanitizr.cleanurl import URLCleaner, ConfigManager

--- a/sanitizr/cleanurl/__init__.py
+++ b/sanitizr/cleanurl/__init__.py
@@ -13,7 +13,7 @@ import importlib.metadata
 try:
     __version__ = importlib.metadata.version("sanitizr")
 except importlib.metadata.PackageNotFoundError:
-    __version__ = "0.1.0.dev"
+    __version__ = "1.0.0"
 
 # Import core components for easier access
 from .core.cleaner import URLCleaner

--- a/sanitizr/cleanurl/cli/__main__.py
+++ b/sanitizr/cleanurl/cli/__main__.py
@@ -56,6 +56,13 @@ def parse_args() -> argparse.Namespace:
         help="Clean a single URL directly from the command line."
     )
     
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 1.0.0",
+        help="Show program's version number and exit."
+    )
+    
     return parser.parse_args()
 
 


### PR DESCRIPTION
This pull request introduces significant updates to the `sanitizr` project, marking its transition from early development to a stable release. The changes include adding a workflow for publishing to PyPI, updating the project's version and status, and improving the CLI with a version flag. Additionally, the documentation has been updated to reflect the availability of the package on PyPI.

### PyPI Publishing Workflow:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R36): Added a GitHub Actions workflow to automate publishing the package to PyPI when a new version tag is pushed to the main branch.

### Project Version and Stability:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L8-R8): Updated the version from `0.1.0` to `1.0.0` and changed the development status classifier from "Alpha" to "Production/Stable." [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L8-R8) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R17)
* `sanitizr/__init__.py` and `sanitizr/cleanurl/__init__.py`: Updated the hardcoded fallback version to `1.0.0` to align with the stable release. [[1]](diffhunk://#diff-e337fa115d26f63e5e969c0a8774b186b323c132ca764e5f4147f9f57066515bL12-R12) [[2]](diffhunk://#diff-215ad628988a1a65dd3c025652bb843fa86b149e81a78374bf812c8248ff4316L16-R16)

### CLI Improvements:
* [`sanitizr/cleanurl/cli/__main__.py`](diffhunk://#diff-4d49387a748aef0e61b8ec78841303abb9de1ce7aaf4e4ce42c2cb5fe2f81bfeR59-R65): Added a `--version` flag to the CLI for displaying the program's version number.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Removed references to early development and updated installation instructions to reflect the availability of the package on PyPI. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R22)