### PR TITLE
Fix output variable assignment in GitHub Actions workflow for version…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,8 +50,9 @@ jobs:
         run: |
           VERSION=$(grep -Po '(?<=version = ")[^"]*' pyproject.toml)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Detected version: $VERSION"
+        shell: bash
 
       - name: Build the package
         run: python -m build


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/publish.yml` file to improve compatibility and clarity in the workflow script.

Workflow improvements:

* Updated the syntax for appending the `version` to `$GITHUB_OUTPUT` by enclosing the variable in curly braces and quoting the output file path for better compatibility.
* Explicitly specified `bash` as the shell to ensure consistent execution across environments.…