### PR TITLE
Fix regex pattern for version extraction in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Extract version
         id: get_version
         run: |
-          VERSION=$(grep -Po '(?<=version = ")[^"]*' pyproject.toml)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Detected version: $VERSION"
+          VERSION=$(grep -Po 'version = "\K[^"]*' pyproject.toml | head -n 1)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Detected version: ${VERSION}"
         shell: bash
 
       - name: Build the package


### PR DESCRIPTION
This pull request includes a small improvement to the version extraction logic in the `.github/workflows/publish.yml` file. The change simplifies the regular expression used to extract the version and ensures only the first match is captured.